### PR TITLE
dirty fix for obfuscated links

### DIFF
--- a/default.py
+++ b/default.py
@@ -454,7 +454,13 @@ def getMovieUrl(url, domain):
         except:
             pass
         
-        if top_url == []:
+        if top_url == [''] or top_url == []:
+            try:
+                url_id = re.search(r"'search','(.+?)',", result).group(1)
+            except:
+                url_id = None
+            if url_id:
+                url = domain + "/watch-special-" + url_id
             try:
                 result = client.request(url, output='geturl')
                 if not domain in result: top_url = result


### PR DESCRIPTION
Waaw linkeken észrevettem, hogy `obfuscator.io`-s JS mögött van a link. Nem találtam rá Pythonos deobfuscator megoldást, viszont ahogy néztem, a listában mindig ugyanott van a kellő ID, szóval regex-szel megpróbálom kiszedni. Eddig amiket néztem, azok elindultak így.